### PR TITLE
Cleanups and Code Structure Improvements

### DIFF
--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP1000_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP1000_ServerGraph.java
@@ -28,6 +28,7 @@ package org.networkcalculus.dnc.experiments.pomacs2017servergraphs;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.experiments.pomacs2017servergraphs.GLP1000_ServerGraph2;
 import org.networkcalculus.dnc.experiments.pomacs2017servergraphs.GLP1000_ServerGraph3;
 import org.networkcalculus.dnc.experiments.pomacs2017servergraphs.GLP1000_ServerGraph4;
@@ -39,7 +40,7 @@ import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 public class GLP1000_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	private GLP1000_ServerGraph() {
 	    

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP100_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP100_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP100_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[141] = server_graph.addServer( "s141", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP120_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP120_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP120_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[163] = server_graph.addServer( "s163", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP140_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP140_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP140_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[52] = server_graph.addServer( "s52", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP160_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP160_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP160_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[123] = server_graph.addServer( "s123", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP180_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP180_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP180_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[77] = server_graph.addServer( "s77", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP200_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP200_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP200_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[83] = server_graph.addServer( "s83", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP20_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP20_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP20_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[34] = server_graph.addServer( "s34", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP220_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP220_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP220_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[355] = server_graph.addServer( "s355", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP240_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP240_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP240_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[682] = server_graph.addServer( "s682", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP260_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP260_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP260_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[882] = server_graph.addServer( "s882", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP280_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP280_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP280_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[245] = server_graph.addServer( "s245", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP300_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP300_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP300_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[1023] = server_graph.addServer( "s1023", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP400_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP400_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP400_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[1475] = server_graph.addServer( "s1475", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP40_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP40_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP40_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[41] = server_graph.addServer( "s41", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP500_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP500_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP500_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[503] = server_graph.addServer( "s503", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP60_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP60_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP60_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[49] = server_graph.addServer( "s49", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );

--- a/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP80_ServerGraph.java
+++ b/java/org/networkcalculus/dnc/experiments/pomacs2017servergraphs/GLP80_ServerGraph.java
@@ -30,13 +30,14 @@ import java.util.LinkedList;
 
 import org.networkcalculus.dnc.AnalysisConfig.Multiplexing;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.network.server_graph.Server;
 import org.networkcalculus.dnc.network.server_graph.ServerGraph;
 
 public class GLP80_ServerGraph{
 	public static ServerGraph server_graph;
 	private static Server[] servers;
-	private static Curve factory = Curve.getFactory();
+	private static CurveFactory_Affine factory = Curve.getFactory();
 	
 	public static void createServers1() throws Exception {
 		servers[188] = server_graph.addServer( "s188", factory.createServiceCurve( "SC{(0.0,0.0),10000.0}" ), factory.createMaxServiceCurve( "MSC{(0.0,0.0),0.0;!(0.0,Infinity),0.0}" ), Multiplexing.ARBITRARY, true, true );


### PR DESCRIPTION
See PR NetCal/DNC#93

The additions make changes needed to break the assumption that all curve backends will work with the same static util methods -- or, put differently, that all curve backends will implement the DNC interface. Ultimately, this is a step towards wrapping the RTC MPA toolbox and using it as a backend for our analyses without duplicating curve util code (see NetCal/DNCext_MPARTC#14 and NetCal/DNC#86).